### PR TITLE
Box location is now only accurate to 250m

### DIFF
--- a/lib/common/extensions/double_extensions.dart
+++ b/lib/common/extensions/double_extensions.dart
@@ -1,0 +1,8 @@
+extension Math on double {
+  /// Rounds the double down to the given decimal place.
+  /// F.eks 59.2633 -> 59.26 with a [place] of 0.01
+  /// F.eks 59.2684 -> 59.26 with a [place] of 0.01
+  double roundDown(double place) {
+    return (this / place).floor() * place;
+  }
+}

--- a/lib/common/utils/Location.dart
+++ b/lib/common/utils/Location.dart
@@ -1,0 +1,20 @@
+import 'package:bookzbox/common/extensions/double_extensions.dart';
+
+class Location {
+  /// Get the coordinate with ~250m accuracy radius.
+  /// When using this function for both a latitude and a longitude coordinate,
+  /// then the new point will have an accuracy of 250-500m depending on the
+  /// start location. It will be on the lower end when closing on the
+  /// poles and on the higher end when closing on the equator.
+  ///
+  /// [coord] The latitude or longitude coordinate to convert
+  ///         from an exact location to within 250m of the given point.
+  ///
+  /// Note: The goal of this function is only to make a coordinate less accurate.
+  ///       If one only has access to the updated coordinate value, then one can only
+  ///       know that the original point was within a ~250m radius of the new point.
+  ///       This is true even if the original point and the new point are only 50m apart.
+  static double getCoordAt250mAccuracy(double coord) {
+    return ((coord * 2.0) + 0.005).roundDown(0.01) / 2.0;
+  }
+}

--- a/lib/features/new_box/stores/new_box_store.dart
+++ b/lib/features/new_box/stores/new_box_store.dart
@@ -1,3 +1,4 @@
+import 'package:bookzbox/common/utils/Location.dart';
 import 'package:bookzbox/features/authentication/authentication.dart';
 import 'package:bookzbox/features/box/models/book.dart';
 import 'package:bookzbox/features/box/models/book_condition.dart';
@@ -117,8 +118,8 @@ abstract class _NewBoxStore with Store {
           books: _books,
           status: BoxStatus.public,
           publishDateTime: DateTime.now(),
-          latitude: p.latitude,
-          longitude: p.longitude,
+          latitude: Location.getCoordAt250mAccuracy(p.latitude),
+          longitude: Location.getCoordAt250mAccuracy(p.longitude),
           title: _boxTitle,
           description: _boxDescription,
         );

--- a/test/utils/location_test.dart
+++ b/test/utils/location_test.dart
@@ -1,0 +1,24 @@
+import 'package:bookzbox/common/utils/Location.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Location Util', () {
+    /// This test expects the default comparator for doubles to use
+    /// an epsilon that is less than three decimal places.
+    test(
+        'When converting a coordinate to 250m accuracy radius, then it should be converted to the nearest half thousand decimal places.',
+        () async {
+      final double a = 59.263333;
+      final double expectedA = 59.265;
+      expect(Location.getCoordAt250mAccuracy(a), expectedA);
+
+      final double b = 59.262222;
+      final double expectedB = 59.26;
+      expect(Location.getCoordAt250mAccuracy(b), expectedB);
+
+      final double c = 59.267981;
+      final double expectedC = 59.27;
+      expect(Location.getCoordAt250mAccuracy(c), expectedC);
+    });
+  });
+}


### PR DESCRIPTION
The location that is published along with a new box is now only accurate to 250m rather than the exact coordinates. 250m should be enough to not give away the exact location of the user while not affecting any functionality.

**Why?**
- This way exact coordinates are not stored in the database.
- Exact coordinates are not necessary for any functionality, thus privacy should be prioritised. Obviously, this is no fix to the privacy issues associated with location, but it can make a difference in metropolitan areas where houses, offices etc are tightly packed.

**Map**
The map is the only functionality that relies on a some what exact location. 250m is not enough to make a difference. It should not matter if the box looks to be published outside of the neighbours house rather than the users own house. This should also not create any issues for clustering.
